### PR TITLE
Don't match .2 in galcom.2a.desc as NUMBER

### DIFF
--- a/stellaris_parser/grammars/lark/events.lark
+++ b/stellaris_parser/grammars/lark/events.lark
@@ -67,7 +67,8 @@ _BLANK_LINE: /[\t ]+\n/
 _NEWLINE: ( NL | COMMENT | _BLANK_LINE )+
 
 STRING: _STRING
-NUMBER: _NUMBER
+// Do not match .9 as a number, it isn't used in stellaris and will match non deterministically match the .2 in galcom.2a.desc
+NUMBER: /[0-9]+(\.[0-9]+)*/
 
 %import common.ESCAPED_STRING   -> _STRING
 %import common.SIGNED_NUMBER    -> _NUMBER


### PR DESCRIPTION
This was causing my copy of your lark file to non deterministically match descriptions incorrectly.